### PR TITLE
epoll loop에 Response 적용하기

### DIFF
--- a/webserv/src/Connection.hpp
+++ b/webserv/src/Connection.hpp
@@ -1,27 +1,14 @@
 #ifndef CONNECTION_HPP
 #define CONNECTION_HPP
 
+#include "response/Response.hpp"
+
 class Request
 {
 public:
 	Request() {}
 	~Request() {}
 	bool ready()
-	{
-		return false;
-	}
-};
-
-class Response
-{
-public:
-	Response() {}
-	~Response() {}
-	bool ready()
-	{
-		return false;
-	}
-	bool sentAll()
 	{
 		return false;
 	}

--- a/webserv/src/Connection.hpp
+++ b/webserv/src/Connection.hpp
@@ -33,6 +33,8 @@ public:
 	{
 		return this->response;
 	}
+
+	void clear();
 };
 
 #endif // CONNECTION_HPP

--- a/webserv/src/ServerManager.cpp
+++ b/webserv/src/ServerManager.cpp
@@ -84,7 +84,7 @@ void ServerManager::loop()
 
 	for (;;)
 	{
-		int nfds = epoll_wait(this->epollFd, events, this->gMaxEvents - 1, 0);
+		int nfds = epoll_wait(this->epollFd, events, MAX_EVENTS, -1);
 		if (nfds == -1)
 			throw std::runtime_error("epoll_wait");
 

--- a/webserv/src/ServerManager.hpp
+++ b/webserv/src/ServerManager.hpp
@@ -7,6 +7,7 @@
 
 #include "ConfigInfo.hpp"
 #include "Connection.hpp"
+#include "response/Response.hpp"
 
 #ifndef BUFFER_SIZE
 #define BUFFER_SIZE 32768
@@ -24,11 +25,13 @@ public:
 private:
 	typedef std::map<int, ConfigInfo> server_container_type;
 	typedef std::map<int, Connection> connection_container_type;
+	typedef std::map<int, int> extra_fd_container_type;
 
 	char buffer[BUFFER_SIZE];
 	int epollFd;
 	server_container_type servers;
 	connection_container_type connections;
+	extra_fd_container_type extraFds;
 
 public:
 	ServerManager(const char *path);
@@ -38,7 +41,7 @@ public:
 
 protected:
 	// used in connect()
-	int addEvent(int clientFd);
+	int addEvent(int clientFd, int option);
 	// used in disconnect()
 	int deleteEvent(int clientFd);
 
@@ -47,7 +50,7 @@ protected:
 	void connect(int serverFd);
 	void disconnect(int clientFd);
 	int receive(int cliendfd);
-	int send(int clinetfd);
+	int send(int clinetfd, Response &response);
 
 private:
 	ServerManager();

--- a/webserv/src/ServerManager.hpp
+++ b/webserv/src/ServerManager.hpp
@@ -46,12 +46,12 @@ public:
 
 protected:
 	// used in connect()
-	int addEvent(int clientFd, int option);
+	int addEvent(int fd, int option);
 	// used in disconnect()
-	int deleteEvent(int clientFd);
+	int deleteEvent(int fd);
 
 	// used in loop()
-	int modifyEvent(int clientFd, struct epoll_event &event, int option);
+	int modifyEvent(int fd, struct epoll_event &event, int option);
 	void connect(int serverFd);
 	void disconnect(int clientFd);
 	int receive(int fd);

--- a/webserv/src/response/Response.cpp
+++ b/webserv/src/response/Response.cpp
@@ -129,7 +129,7 @@ std::pair<int, int> Response::process(Request &req, ConfigInfo &config)
 		}
 	}
 
-	this->body.fd = open(targetPath.c_str(), O_RDONLY);
+	this->body.fd = open(targetPath.c_str(), O_RDONLY | O_NONBLOCK);
 	if (this->body.fd == -1)
 		throw(404);
 	setHeader("Content-Type", MediaType::get(UriParser(targetPath).getExtension()));
@@ -154,7 +154,7 @@ std::pair<int, int> Response::process(int errorCode, ConfigInfo &config, bool cl
 	if (config.errorPages.find(errorCode) != config.errorPages.end())
 	{
 		errorPage = config.errorPages[errorCode];
-		this->body.fd = open(errorPage.c_str(), O_RDONLY);
+		this->body.fd = open(errorPage.c_str(), O_RDONLY | O_NONBLOCK);
 		if (this->body.fd != -1)
 		{
 			setHeader("Content-Type", MediaType::get(UriParser(errorPage).getExtension()));

--- a/webserv/src/response/Response.cpp
+++ b/webserv/src/response/Response.cpp
@@ -51,6 +51,11 @@ bool Response::done() const
 	return (ready() && this->sentBytes == this->totalBytes);
 }
 
+bool Response::close() const
+{
+	return (this->isClose);
+}
+
 void Response::clear()
 {
 	this->buffer.clear();

--- a/webserv/src/response/Response.cpp
+++ b/webserv/src/response/Response.cpp
@@ -10,8 +10,8 @@
 
 #include <dirent.h>
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <sys/epoll.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #define SERVER_NAME "webserv"
@@ -30,7 +30,14 @@ std::string toString(T value)
 }
 } // namespace ft
 
-Response::Response() : statusCode(200), body(), sentBytes(0), totalBytes(0), isReady(false) {}
+Response::Response()
+		: statusCode(200), body(), sentBytes(0), totalBytes(0), isReady(false), isClose(false)
+{}
+
+Response::Response(const Response &other)
+		: statusCode(other.statusCode), header(other.header), body(), buffer(other.buffer),
+			sentBytes(0), totalBytes(0), isReady(false), isClose(other.isClose)
+{}
 
 Response::~Response() {}
 
@@ -182,8 +189,8 @@ std::string Response::generateDefaultErrorPage(int code) const
 	return (html.str());
 }
 
-std::string Response::generateFileListPage(
-		const std::string &path, const std::vector<std::string> &files) const
+std::string
+Response::generateFileListPage(const std::string &path, const std::vector<std::string> &files) const
 {
 	std::stringstream html;
 	std::size_t totalFiles = files.size();
@@ -346,8 +353,8 @@ std::vector<std::string> Response::readDirectory(const std::string &path)
 	return (files);
 }
 
-std::string Response::searchIndexFile(
-		const std::vector<std::string> &files, const std::vector<std::string> &indexFiles)
+std::string Response::searchIndexFile(const std::vector<std::string> &files,
+																			const std::vector<std::string> &indexFiles)
 {
 	std::size_t indexSize;
 	std::vector<std::string>::const_iterator found;

--- a/webserv/src/response/Response.hpp
+++ b/webserv/src/response/Response.hpp
@@ -39,6 +39,7 @@ public:
 
 	bool ready() const;
 	bool done() const;
+	bool close() const;
 	void clear();
 
 	const char *getBuffer() const;

--- a/webserv/src/response/Response.hpp
+++ b/webserv/src/response/Response.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 class Response
@@ -44,9 +45,9 @@ public:
 	std::size_t moveBufPosition(int nbyte);
 
 	template<class Request, class ConfigInfo>
-	void process(Request &req, ConfigInfo &config);
+	std::pair<int, int> process(Request &req, ConfigInfo &config);
 	template<class ConfigInfo>
-	void process(int errorCode, ConfigInfo &config, bool close = false);
+	std::pair<int, int> process(int errorCode, ConfigInfo &config, bool close = false);
 
 	int readBody();
 
@@ -64,16 +65,16 @@ private:
 	void setHeader(std::string name, std::string value);
 	void setBuffer();
 
-	void setBodyToDefaultPage(const std::string &html);
+	std::pair<int, int> setBodyToDefaultPage(const std::string &html);
 	std::string generateDefaultErrorPage(int code) const;
-	std::string generateFileListPage(
-			const std::string &path, const std::vector<std::string> &files) const;
+	std::string
+	generateFileListPage(const std::string &path, const std::vector<std::string> &files) const;
 
 	void clearBody(Body &body);
 
 	std::vector<std::string> readDirectory(const std::string &path);
-	std::string searchIndexFile(
-			const std::vector<std::string> &files, const std::vector<std::string> &indexFiles);
+	std::string searchIndexFile(const std::vector<std::string> &files,
+															const std::vector<std::string> &indexFiles);
 };
 
 #endif // !RESPONSE_HPP

--- a/webserv/src/response/Response.hpp
+++ b/webserv/src/response/Response.hpp
@@ -34,6 +34,7 @@ private:
 
 public:
 	Response();
+	Response(const Response &other);
 	~Response();
 
 	bool ready() const;
@@ -52,9 +53,6 @@ public:
 	int readBody();
 
 private:
-	Response(const Response &other);
-	Response &operator=(const Response &rhs);
-
 	std::string timeInfoToString(std::tm *timeInfo, const std::string format) const;
 	std::string getCurrentTime() const;
 


### PR DESCRIPTION
resolve #22

epoll loop에 하나씩 붙여나갈 때가 된 것 같습니다..!

응답 메시지 생성을 위해 파일/cgi의 I/O 이벤트를 루프에 추가했습니다.
에러 응답 처리를 위해 try catch문을 사용했고 기존 for문을 감싸던 try catch를 제거하고 throw() 대신 disconnect() 하도록 수정했습니다.
cgi를 진행하기 앞서 epoll loop와 Response의 동기화가 필요하다고 느껴져서 수정을 해봤는데 리뷰 부탁드립니다!